### PR TITLE
Fix SSH box parsing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <!-- PROJECT SHIELDS -->
 <!--
 *** I'm using markdown "reference style" links for readability.
+
 *** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
 *** See the bottom of this document for the declaration of the reference variables
 *** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@
   <a href="https://xwang.dev/blog/2024/opendevin-codeact-1.0-swebench/"><img src="https://img.shields.io/badge/SWE--bench%20Lite-21.0%25-green?style=for-the-badge" alt="SWE-bench "></a>
 </div>
 
+
+
+
 <!-- PROJECT LOGO -->
 <div align="center">
   <img src="./docs/static/img/logo.png" alt="Logo" width="200" height="200">

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -110,6 +110,7 @@ class AgentController:
                 await self.report_error(
                     'There was an unexpected error while running the agent'
                 )
+                self.state.error = str(e)
                 await self.set_agent_state_to(AgentState.ERROR)
                 break
 
@@ -189,6 +190,7 @@ class AgentController:
         logger.info(f'STEP {self.state.iteration}', extra={'msg_type': 'STEP'})
         if self.state.iteration >= self.max_iterations:
             await self.report_error('Agent reached maximum number of iterations')
+            self.state.error = 'Agent reached maximum number of iterations'
             await self.set_agent_state_to(AgentState.ERROR)
             return
 
@@ -228,6 +230,7 @@ class AgentController:
 
         if self._is_stuck():
             await self.report_error('Agent got stuck in a loop')
+            self.state.error = 'Agent got stuck in a loop'
             await self.set_agent_state_to(AgentState.ERROR)
 
     def get_state(self):

--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -119,6 +119,7 @@ async def main(
         await asyncio.sleep(1)  # Give back control for a tick, so the agent can run
 
     await controller.close()
+    runtime.close()
     return controller.get_state()
 
 

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -378,7 +378,7 @@ class DockerSSHBox(Sandbox):
             logger.debug(
                 f'WAITING FOR END OF command output ({bool(output)}): {output}'
             )
-            if output == '':
+            if output.strip() == '':
                 break
             command_output += output
         command_output = command_output.removesuffix('\r\n')
@@ -386,17 +386,19 @@ class DockerSSHBox(Sandbox):
         # get the exit code
         self.ssh.sendline('echo $?')
         self.ssh.prompt()
-        exit_code_str = self.ssh.before
+        exit_code_str = self.ssh.before.strip()
         _start_time = time.time()
         while not exit_code_str:
-            self.ssh.prompt()
-            exit_code_str = self.ssh.before
+            self.ssh.prompt(timeout=1)
+            exit_code_str = self.ssh.before.strip()
             logger.debug(f'WAITING FOR exit code: {exit_code_str}')
             if time.time() - _start_time > timeout:
                 return self._send_interrupt(
                     cmd, command_output, ignore_last_output=True
                 )
-        exit_code = int(exit_code_str.strip())
+        exit_code = int(
+            exit_code_str.replace('echo $?', '').replace('\r\n', '').strip()
+        )
         return exit_code, command_output
 
     def copy_to(self, host_src: str, sandbox_dest: str, recursive: bool = False):


### PR DESCRIPTION
- Improved the handling of empty command output in the `execute()` method of the `SSHBox` class
- Added error handling for cases where the exit code is not immediately available, by retrying the command output retrieval with a timeout
- Ensured that the exit code is properly parsed and returned as an integer value

## Files

### opendevin/runtime/docker/ssh_box.py
**Title:** Improve SSH box command execution

**Changes Summary:**
- Fixed an issue where the `execute()` method would not correctly handle empty command output
- Added a timeout and retry mechanism to ensure the exit code is properly retrieved
- Improved the parsing of the exit code to return an integer value

**Label:** bug fix

### opendevin/controller/agent_controller.py
**Title:** Handle agent errors

**Changes Summary:**
- Added error handling to the `_start_step_loop()` and `_step()` methods to set the agent state to `ERROR` and store the error message in the agent state

**Label:** bug fix

### opendevin/core/main.py
**Title:** Close runtime on event completion

**Changes Summary:**
- Added a call to `runtime.close()` to ensure the runtime is properly closed when the `on_event()` function completes

**Label:** enhancement



===== Original PR title and description ============

**Original Title:** Xw/fix ssh box parsing

**Original Description:**
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**

